### PR TITLE
enable smtp tls sending encryption

### DIFF
--- a/assets/install.sh
+++ b/assets/install.sh
@@ -85,6 +85,7 @@ postconf -e milter_protocol=2
 postconf -e milter_default_action=accept
 postconf -e smtpd_milters=inet:localhost:12301
 postconf -e non_smtpd_milters=inet:localhost:12301
+postconf -e smtp_tls_security_level=encrypt
 
 cat >> /etc/opendkim.conf <<EOF
 AutoRestart             Yes


### PR DESCRIPTION
This enables postfix smtp tls send which allows it pass the check found at http://www.checktls.com/perl/TestSender.pl
