### PR TITLE
force 'smtpd_use_tls=no' if no keys specified

### DIFF
--- a/assets/install.sh
+++ b/assets/install.sh
@@ -66,6 +66,8 @@ if [[ -n "$(find /etc/postfix/certs -iname *.crt)" && -n "$(find /etc/postfix/ce
   postconf -P "submission/inet/smtpd_sasl_auth_enable=yes"
   postconf -P "submission/inet/milter_macro_daemon_name=ORIGINATING"
   postconf -P "submission/inet/smtpd_recipient_restrictions=permit_sasl_authenticated,reject_unauth_destination"
+else
+  postconf -e smtpd_use_tls=no
 fi
 
 #############


### PR DESCRIPTION
otherwise postfix return '250-STARTTLS' but then failed because no keys
available. This can cause Wordpress failed to send emails because 'wp
mail smtp' force to use TLS if server return '250-STARTTLS'

Signed-off-by: Abylay Ospan aospan@netup.ru
