### PR TITLE
mynetworks env variable, some cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ MAINTAINER Elliott Ye
 # Set noninteractive mode for apt-get
 ENV DEBIAN_FRONTEND noninteractive
 
-# Update
-RUN apt-get update
-
-# Start editing
-# Install package here for cache
-RUN apt-get -y install supervisor postfix sasl2-bin opendkim opendkim-tools
+RUN apt-get update && apt-get install -y \
+    opendkim \
+    opendkim-tools \
+    postfix \
+    supervisor \
+    sasl2-bin
 
 # Add files
 ADD assets/install.sh /opt/install.sh

--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ TLS and OpenDKIM support are optional.
 			--name postfix -d catatnight/postfix
 	```
 
+4. (Optional) Configure postfix to allow relaying from a local docker network (containers in the same network):
+```
+network=`docker network inspect --format='{{range .IPAM.Config}}{{.Subnet}}{{end}}' my_docker_network`
+
+docker run -d --name smtp \
+  --net=my_docker_network \
+  -e maildomain=mydomain.localhost \
+  -e mynetworks=127.0.0.0/8,$network \
+  myrepo/postfix
+```
+
 ## Note
 + Login credential should be set to (`username@mail.example.com`, `password`) in Smtp Client
 + You can assign the port of MTA on the host machine to one other than 25 ([postfix how-to](http://www.postfix.org/MULTI_INSTANCE_README.html))


### PR DESCRIPTION
Pass mynetworks env var to postfix to allow relaying from a local docker network.

Fixed Dockerfile to update and install in the same run as per best practices (https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/)

Check $maildomain, warn/exit if unset

