### PR TITLE
Adding support for secrets in docker swarm

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ TLS and OpenDKIM support are optional.
 
 ## Note
 + Login credential should be set to (`username@mail.example.com`, `password`) in Smtp Client
++ If `smtp_user` is set to an existing file, the `user:password` string will be read from that file
+  (to allow integration with docker-swarm secrets).
 + You can assign the port of MTA on the host machine to one other than 25 ([postfix how-to](http://www.postfix.org/MULTI_INSTANCE_README.html))
 + Read the reference below to find out how to generate domain keys and add public key to the domain's DNS records
 

--- a/assets/install.sh
+++ b/assets/install.sh
@@ -45,7 +45,11 @@ auxprop_plugin: sasldb
 mech_list: PLAIN LOGIN CRAM-MD5 DIGEST-MD5 NTLM
 EOF
 # sasldb2
-echo $smtp_user | tr , \\n > /tmp/passwd
+if  [ -f /run/secrets/smtp_user ]; then
+    cat /run/secrets/smtp_user | tr , \\n > /tmp/passwd
+else
+    echo $smtp_user | tr , \\n > /tmp/passwd
+fi
 while IFS=':' read -r _user _pwd; do
   echo $_pwd | saslpasswd2 -p -c -u $maildomain $_user
 done < /tmp/passwd


### PR DESCRIPTION
Secrets is a nice feature of swarms. I'd like to use this nice docker image of yours using a secret to add a user.
The hack in this PR should do the trick. I am open to discussion.