### PR TITLE
upgrade to ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-From ubuntu:trusty
+From ubuntu:20.04
 MAINTAINER Elliott Ye
 
 # Set noninteractive mode for apt-get
@@ -9,7 +9,7 @@ RUN apt-get update
 
 # Start editing
 # Install package here for cache
-RUN apt-get -y install supervisor postfix sasl2-bin opendkim opendkim-tools
+RUN apt-get -y install supervisor postfix sasl2-bin opendkim opendkim-tools rsyslog libssl1.1
 
 # Add files
 ADD assets/install.sh /opt/install.sh


### PR DESCRIPTION
Upgrade to ubuntu 20.04 for security because maintenance update is not availabe for ubuntu:trusty. #23